### PR TITLE
Explicitly specifying file encoding when opening a file with Python. …

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@
 
 from setuptools import setup
 
-with open("README.md") as f:
+with open("README.md", encoding="utf8") as f:
     long_description = f.read()  # pylint: disable=invalid-name
 
 TEST_DEPS = [

--- a/src/statick_tooling/plugins/tool/dockerfile_lint_tool_plugin.py
+++ b/src/statick_tooling/plugins/tool/dockerfile_lint_tool_plugin.py
@@ -69,7 +69,7 @@ class DockerfileULintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 

--- a/src/statick_tooling/plugins/tool/dockerfilelint_tool_plugin.py
+++ b/src/statick_tooling/plugins/tool/dockerfilelint_tool_plugin.py
@@ -71,7 +71,7 @@ class DockerfileLintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 

--- a/src/statick_tooling/plugins/tool/hadolint_tool_plugin.py
+++ b/src/statick_tooling/plugins/tool/hadolint_tool_plugin.py
@@ -87,7 +87,7 @@ class HadolintToolPlugin(ToolPlugin):  # type: ignore
         for output in total_output:
             logging.debug("%s", output)
 
-        with open(self.get_name() + ".log", "w") as fid:
+        with open(self.get_name() + ".log", "w", encoding="utf8") as fid:
             for output in total_output:
                 fid.write(output)
 


### PR DESCRIPTION
…Fixes pylint warning.

Signed-off-by: Alexander Xydes <alexander.xydes@navy.mil>