### PR TITLE
Run tool plugins against all files at once when possible.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
 ### Added
 
+- Process all source files at once with tools that support passing in a list of files, instead of invoking each tool
+  per file.
+
 ### Fixed
 
 ## v0.1.1 - 2022-10-11

--- a/src/statick_tooling/plugins/tool/dockerfilelint_tool_plugin.py
+++ b/src/statick_tooling/plugins/tool/dockerfilelint_tool_plugin.py
@@ -46,28 +46,25 @@ class DockerfileLintToolPlugin(ToolPlugin):  # type: ignore
 
         total_output: List[str] = []
 
-        for src in files:
-            try:
-                exe = [tool_bin] + flags + [src]
-                output = subprocess.check_output(
-                    exe, stderr=subprocess.STDOUT, universal_newlines=True
-                )
-                total_output.append(output)
+        try:
+            exe = [tool_bin] + flags + files
+            output = subprocess.check_output(
+                exe, stderr=subprocess.STDOUT, universal_newlines=True
+            )
+            total_output.append(output)
 
-            except subprocess.CalledProcessError as ex:
-                # dockerfilelint returns the number of linting errors as the return code
-                if ex.returncode > 0:
-                    total_output.append(ex.output)
-                else:
-                    logging.warning(
-                        "%s failed! Returncode = %d", tool_bin, ex.returncode
-                    )
-                    logging.warning("%s exception: %s", self.get_name(), ex.output)
-                    return None
-
-            except OSError as ex:
-                logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+        except subprocess.CalledProcessError as ex:
+            # dockerfilelint returns the number of linting errors as the return code
+            if ex.returncode > 0:
+                total_output.append(ex.output)
+            else:
+                logging.warning("%s failed! Returncode = %d", tool_bin, ex.returncode)
+                logging.warning("%s exception: %s", self.get_name(), ex.output)
                 return None
+
+        except OSError as ex:
+            logging.warning("Couldn't find %s! (%s)", tool_bin, ex)
+            return None
 
         for output in total_output:
             logging.debug("%s", output)


### PR DESCRIPTION
Significantly speeds up many of the tool plugin runtime durations.