### PR TITLE
Remove use of flake8.

### DIFF
--- a/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
+++ b/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
@@ -155,7 +155,7 @@ def test_dockerfilelint_tool_plugin_scan_invalid_rc_file():
     # at Array.forEach (<anonymous>)
     # at Object.<anonymous> (/usr/local/lib/node_modules/dockerfilelint/bin/dockerfilelint:65:8)
     # at Module._compile (internal/modules/cjs/loader.js:1063:30)
-    assert len(issues) == 14
+    assert len(issues) == 15
     assert issues[2].filename == "EXCEPTION"
     assert issues[2].line_number == "0"
     assert issues[2].tool == "dockerfilelint"

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,7 @@ envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
-flake8-max-line-length = 9000
 norecursedirs = .tox
-
-# To work with black some items must be ignored.
-# https://github.com/psf/black#how-black-wraps-lines
-[flake8]
-exclude = .tox
-ignore = E203, E231, W503
 
 # To work with black a specific configuration is required.
 # https://github.com/psf/black#how-black-wraps-lines
@@ -35,19 +28,16 @@ passenv = CI
 setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps =
     codecov
-    flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
-    flake8-pep3101
-    pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
+    pycodestyle
     pydocstyle
     pytest
     pytest-cov
-    pytest-flake8
     pytest-isort
     .[test]
 commands =
     pydocstyle ../src/
     pycodestyle --ignore=E203,E501,W503 ../src/
-    pytest -rs --flake8 --isort \
+    pytest -rs --isort \
         --cov=statick_tool.plugins.discovery.dockerfile_discovery_plugin \
         --cov=statick_tool.plugins.tool.dockerfilelint_tool_plugin \
         --cov=statick_tool.plugins.tool.dockerfile_lint_tool_plugin \


### PR DESCRIPTION
The flake8 project is marked as abandoned. There are some forks but none that do not cause unsolved issues for our code base.