### PR TITLE
Remove use of flake8.

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,8 +80,8 @@ jobs:
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "uname -s " uname -s
-          echo "uname -m " uname -m
+          echo "uname -s " $(uname -s)
+          echo "uname -m " $(uname -m)
           curl -sL -o hadolint https://github.com/hadolint/hadolint/releases/download/v2.6.0/hadolint-$(uname -s)-$(uname -m)
           chmod +x hadolint
           mv hadolint $HOME/.local/bin/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -78,11 +78,11 @@ jobs:
 
       - name: Install Hadolint binary (github)
         run: |
-          mkdir hadolint-bin
+          mkdir -p $HOME/.local/bin
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           curl -sL -o hadolint https://github.com/hadolint/hadolint/releases/download/v2.6.0/hadolint-$(uname -s)-$(uname -m)
           chmod +x hadolint
-          mv hadolint hadolint-bin/.
-          echo "$GITHUB_WORKSPACE/hadolint-bin" >> $GITHUB_PATH
+          mv hadolint $HOME/.local/bin/
 
       - name: Install Hadolint docker image (Linux)
         if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04'
@@ -95,8 +95,8 @@ jobs:
 
       - name: Tox
         run: |
-          ls "$GITHUB_WORKSPACE/hadolint-bin"
-          echo "$GITHUB_WORKSPACE/hadolint-bin" >> $GITHUB_PATH
+          ls "$HOME/.local/bin"
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
           python -m tox
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -76,7 +76,9 @@ jobs:
           npm install -g dockerfilelint
           npm install -g dockerfile_lint
 
+      # Do not install on macos until there is a hadolint release for macos (Darwin on arm64 architecture).
       - name: Install Hadolint binary (github)
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04' || matrix.os == 'windows-latest'
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
@@ -93,9 +95,7 @@ jobs:
         run: |
           mypy --ignore-missing-imports --strict src/
 
-      # Do not run on macos until there is a hadolint release for macos (Darwin on arm64 architecture).
       - name: Tox
-        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04' || matrix.os == 'windows-latest'
         run: |
           python -m tox
 

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,8 +80,6 @@ jobs:
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
-          echo "uname -s " $(uname -s)
-          echo "uname -m " $(uname -m)
           curl -sL -o hadolint https://github.com/hadolint/hadolint/releases/download/v2.6.0/hadolint-$(uname -s)-$(uname -m)
           chmod +x hadolint
           mv hadolint $HOME/.local/bin/
@@ -95,10 +93,10 @@ jobs:
         run: |
           mypy --ignore-missing-imports --strict src/
 
+      # Do not run on macos until there is a hadolint release for macos (Darwin on arm64 architecture).
       - name: Tox
+        if: matrix.os == 'ubuntu-20.04' || matrix.os == 'ubuntu-22.04' || matrix.os == 'windows-latest'
         run: |
-          ls -lh $HOME/.local/bin
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
           python -m tox
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,7 +95,8 @@ jobs:
 
       - name: Tox
         run: |
-          ls hadolint-bin
+          ls "$GITHUB_WORKSPACE/hadolint-bin"
+          echo "$GITHUB_WORKSPACE/hadolint-bin" >> $GITHUB_PATH
           python -m tox
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,6 +95,7 @@ jobs:
 
       - name: Tox
         run: |
+          hadolint
           python -m tox
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -80,6 +80,8 @@ jobs:
         run: |
           mkdir -p $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
+          echo "uname -s " uname -s
+          echo "uname -m " uname -m
           curl -sL -o hadolint https://github.com/hadolint/hadolint/releases/download/v2.6.0/hadolint-$(uname -s)-$(uname -m)
           chmod +x hadolint
           mv hadolint $HOME/.local/bin/

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Tox
         run: |
-          hadolint
+          ls hadolint-bin
           python -m tox
 
       - name: Upload coverage to Codecov

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -95,7 +95,7 @@ jobs:
 
       - name: Tox
         run: |
-          ls "$HOME/.local/bin"
+          ls -lh $HOME/.local/bin
           echo "$HOME/.local/bin" >> $GITHUB_PATH
           python -m tox
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 """Setup."""
 
-
 from setuptools import setup
 
 with open("README.md", encoding="utf8") as f:

--- a/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
+++ b/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
@@ -155,7 +155,7 @@ def test_dockerfilelint_tool_plugin_scan_invalid_rc_file():
     # at Array.forEach (<anonymous>)
     # at Object.<anonymous> (/usr/local/lib/node_modules/dockerfilelint/bin/dockerfilelint:65:8)
     # at Module._compile (internal/modules/cjs/loader.js:1063:30)
-    assert len(issues) == 15
+    assert len(issues) == 14
     assert issues[2].filename == "EXCEPTION"
     assert issues[2].line_number == "0"
     assert issues[2].tool == "dockerfilelint"

--- a/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
+++ b/tests/tool/dockerfilelint_tool_plugin/test_dockerfilelint_tool_plugin.py
@@ -155,7 +155,7 @@ def test_dockerfilelint_tool_plugin_scan_invalid_rc_file():
     # at Array.forEach (<anonymous>)
     # at Object.<anonymous> (/usr/local/lib/node_modules/dockerfilelint/bin/dockerfilelint:65:8)
     # at Module._compile (internal/modules/cjs/loader.js:1063:30)
-    assert len(issues) == 14
+    assert len(issues) == 15
     assert issues[2].filename == "EXCEPTION"
     assert issues[2].line_number == "0"
     assert issues[2].tool == "dockerfilelint"

--- a/tox.ini
+++ b/tox.ini
@@ -3,14 +3,7 @@ envlist = py38, py39, py310, py311
 skip_missing_interpreters = true
 
 [pytest]
-flake8-max-line-length = 9000
 norecursedirs = .tox
-
-# To work with black some items must be ignored.
-# https://github.com/psf/black#how-black-wraps-lines
-[flake8]
-exclude = .tox
-ignore = E203, E231, W503
 
 # To work with black a specific configuration is required.
 # https://github.com/psf/black#how-black-wraps-lines
@@ -35,19 +28,16 @@ passenv = CI
 setenv = PY_IGNORE_IMPORTMISMATCH = 1
 deps =
     codecov
-    flake8<5  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
-    flake8-pep3101
-    pycodestyle<2.9.0  # Pin until https://github.com/tholo/pytest-flake8/issues/87 is fixed.
+    pycodestyle
     pydocstyle
     pytest
     pytest-cov
-    pytest-flake8
     pytest-isort
     .[test]
 commands =
     pydocstyle ../src/
     pycodestyle --ignore=E203,E501,W503 ../src/
-    pytest -rs --flake8 --isort \
+    pytest -rs --isort \
         --cov=statick_tool.plugins.discovery.dockerfile_discovery_plugin \
         --cov=statick_tool.plugins.tool.dockerfilelint_tool_plugin \
         --cov=statick_tool.plugins.tool.dockerfile_lint_tool_plugin \


### PR DESCRIPTION
The flake8 project is marked as abandoned. There are some forks but none that do not cause unsolved issues for our code base.