### PR TITLE
Preparing for v0.4.0 release.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,17 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 
+## v0.4.0 - 2025-02-07
+
+This set of plugins was merged into the main [Statick] repository and Python package.
+All future development will happen in that repository.
+
+### Updated
+
+- The Statick dependency was pinned to lower than version 0.12.
+  - This will ensure these plugins are not installed in the same space as the main `statick` package.
+    Having both packages installed would cause conflicts between plugins.
+
 ## v0.3.0 - 2025-01-20
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Custom exceptions can be applied the same way they are with [Statick exceptions]
 
 - [Statick Tooling Plugins](#statick-tooling-plugins)
   - [Table of Contents](#table-of-contents)
+  - [Deprecated](#deprecated)
   - [Installation](#installation)
   - [Usage](#usage)
     - [Pip Install](#pip-install)
@@ -30,6 +31,11 @@ Custom exceptions can be applied the same way they are with [Statick exceptions]
   - [Contributing](#contributing)
     - [Mypy](#mypy)
     - [Formatting](#formatting)
+
+## Deprecated
+
+This set of plugins was merged into the main [Statick] repository and Python package.
+All future development will happen in that repository.
 
 ## Installation
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "statick-tooling"
 authors = [{name = "NIWC Pacific"}]
 description="Statick analysis plugins for Tooling files."
-version = "0.3.0"
+version = "0.4.0"
 readme = "README.md"
 requires-python = ">=3.9"
 license = {text = "CC0-1.0"}
@@ -25,7 +25,7 @@ classifiers = [
 
 dependencies = [
     "importlib_metadata",
-    "statick",
+    "statick<0.12",
     "types-docutils",
 ]
 


### PR DESCRIPTION
- Marking package as deprecated.
- All plugins moved to main `statick` package.
- Pinned `statick` dependency to lower than v0.12 to avoid module collisions.